### PR TITLE
Made delays match the method names

### DIFF
--- a/AsyncAwaitStopwatchDemo/Tasks.cs
+++ b/AsyncAwaitStopwatchDemo/Tasks.cs
@@ -9,19 +9,19 @@ namespace AsyncAwaitStopwatchDemo
     {
         public async Task OneSecondTask()
         {
-            await Task.Delay(2000);
+            await Task.Delay(1000);
             return;
         }
 
         public async Task FourSecondTask()
         {
-            await Task.Delay(10000);
+            await Task.Delay(4000);
             return;
         }
 
         public async Task TwoSecondTask()
         {
-            await Task.Delay(5000);
+            await Task.Delay(2000);
             return;
         }
 


### PR DESCRIPTION
There was a mismatch. Also in the [blog-post](https://www.exceptionnotfound.net/using-stopwatch-and-continuewith-to-measure-task-execution-time-in-c/), so it seems strange that the `FourSecondTask` takes 10s to complete.